### PR TITLE
Added Voltage Offset

### DIFF
--- a/ads1110.c
+++ b/ads1110.c
@@ -73,10 +73,8 @@ int ads1110_open(t_ads1110 *sensor, unsigned char i2c_address)
 int ads1110_init(t_ads1110 *sensor)
 {
 	// set calibration data
-	//sensor->voltage_factor = 2.;
-  if (sensor->voltage_factor[1]==0) { 
-	ddebug_print("%s @ 0x%x: voltage_factor=%f\n", __func__, sensor->address, 1.0/sensor->voltage_factor[0]);
-  } else { ddebug_print("%s @ 0x%x: voltage_factor=%f + %f\n", __func__, sensor->address, 1.0/sensor->voltage_factor[0],sensor->voltage_factor[1]); }	
+
+        ddebug_print("%s @ 0x%x: voltage_scale = %f voltage_offset = %f\n", __func__, sensor->address, 1.0/sensor->scale,sensor->offset);	
 	return(0);
 	
 }
@@ -106,7 +104,7 @@ int ads1110_measure(t_ads1110 *sensor)
 int ads1110_calculate(t_ads1110 *sensor)
 {
 
-	sensor->voltage_converted = (sensor->voltage_raw*sensor->voltage_factor[0]+sensor->voltage_factor[1]);
+	sensor->voltage_converted = (sensor->voltage_raw*sensor->scale+sensor->offset);
 	
 	debug_print("%s @ 0x%x: Voltage: %fV\n", __func__, sensor->address, sensor->voltage_converted);
 

--- a/ads1110.c
+++ b/ads1110.c
@@ -74,8 +74,9 @@ int ads1110_init(t_ads1110 *sensor)
 {
 	// set calibration data
 	//sensor->voltage_factor = 2.;
-	ddebug_print("%s @ 0x%x: voltage_factor=%f\n", __func__, sensor->address, sensor->voltage_factor);
-	
+  if (sensor->voltage_factor[1]==0) { 
+	ddebug_print("%s @ 0x%x: voltage_factor=%f\n", __func__, sensor->address, 1.0/sensor->voltage_factor[0]);
+  } else { ddebug_print("%s @ 0x%x: voltage_factor=%f + %f\n", __func__, sensor->address, 1.0/sensor->voltage_factor[0],sensor->voltage_factor[1]); }	
 	return(0);
 	
 }
@@ -105,7 +106,7 @@ int ads1110_measure(t_ads1110 *sensor)
 int ads1110_calculate(t_ads1110 *sensor)
 {
 
-	sensor->voltage_converted = (sensor->voltage_raw/sensor->voltage_factor);
+	sensor->voltage_converted = (sensor->voltage_raw*sensor->voltage_factor[0]+sensor->voltage_factor[1]);
 	
 	debug_print("%s @ 0x%x: Voltage: %fV\n", __func__, sensor->address, sensor->voltage_converted);
 

--- a/ads1110.h
+++ b/ads1110.h
@@ -19,7 +19,8 @@
 
 // define struct for AMS5915 sensor
 typedef struct {
-	float voltage_factor[2];
+	float scale;
+        float offset;
 	int voltage_raw;
 	float voltage_converted;
 	int fd;

--- a/ads1110.h
+++ b/ads1110.h
@@ -19,7 +19,7 @@
 
 // define struct for AMS5915 sensor
 typedef struct {
-	float voltage_factor;
+	float voltage_factor[2];
 	int voltage_raw;
 	float voltage_converted;
 	int fd;

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -106,8 +106,8 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 				if (strcmp(tmp,"voltage_config") == 0)
 				{
 					// get config data for dynamic sensor
-				        sscanf(line, "%s %f %f", tmp, &voltage_sensor->voltage_factor[0],&voltage_sensor->voltage_factor[1]);
-				        voltage_sensor->voltage_factor[0]=1.0/voltage_sensor->voltage_factor[0];
+				        sscanf(line, "%s %f %f", tmp, &voltage_sensor->scale,&voltage_sensor->offset);
+				        voltage_sensor->scale=1.0/voltage_sensor->scale;
 				}
 			}
 	

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -44,14 +44,14 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 		{
 			// get line from config file
 			fgets(line, 70, fp);
-			//printf("getting line: '%s'\n", line);
+			//printf("getting line: '%69s'\n", line);
 			
 			// check if line is comment
 			if((!(line[0] == '#')) && (!(line[0] == '\n')))
 			{
 			
 				// get first config tag
-				sscanf(line, "%s", tmp);
+				sscanf(line, "%69s", tmp);
 				
 				// check for output of POV_E sentence
 				if (strcmp(tmp,"output_POV_E") == 0)
@@ -78,35 +78,35 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 				if (strcmp(tmp,"static_sensor") == 0)
 				{
 					// get config data for static sensor
-					sscanf(line, "%s %f %f", tmp, &static_sensor->offset, &static_sensor->linearity);
+					sscanf(line, "%69s %f %f", tmp, &static_sensor->offset, &static_sensor->linearity);
 				}
 				
 				// check for tek_sensor
 				if (strcmp(tmp,"tek_sensor") == 0)
 				{
 					// get config data for tek sensor
-					sscanf(line, "%s %f %f", tmp, &tek_sensor->offset, &tek_sensor->linearity);	
+					sscanf(line, "%69s %f %f", tmp, &tek_sensor->offset, &tek_sensor->linearity);	
 				}
 				
 				// check for dynamic_sensor
 				if (strcmp(tmp,"dynamic_sensor") == 0)
 				{
 					// get config data for dynamic sensor
-					sscanf(line, "%s %f %f", tmp, &dynamic_sensor->offset, &dynamic_sensor->linearity);
+					sscanf(line, "%69s %f %f", tmp, &dynamic_sensor->offset, &dynamic_sensor->linearity);
 				}
 				
 				// check for vario config
 				if (strcmp(tmp,"vario_config") == 0)
 				{
 					// get config data for dynamic sensor
-					sscanf(line, "%s %f", tmp, &config->vario_x_accel);
+					sscanf(line, "%69s %f", tmp, &config->vario_x_accel);
 				}
 				
 				// check for voltage sensor config
 				if (strcmp(tmp,"voltage_config") == 0)
 				{
 					// get config data for dynamic sensor
-				        sscanf(line, "%s %f %f", tmp, &voltage_sensor->scale,&voltage_sensor->offset);
+				        sscanf(line, "%69s %f %f", tmp, &voltage_sensor->scale,&voltage_sensor->offset);
 				        voltage_sensor->scale=1.0/voltage_sensor->scale;
 				}
 			}

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -51,7 +51,7 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 			{
 			
 				// get first config tag
-				sscanf(line, "%69s", tmp);
+				sscanf(line, "%19s", tmp);
 				
 				// check for output of POV_E sentence
 				if (strcmp(tmp,"output_POV_E") == 0)
@@ -78,35 +78,35 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 				if (strcmp(tmp,"static_sensor") == 0)
 				{
 					// get config data for static sensor
-					sscanf(line, "%69s %f %f", tmp, &static_sensor->offset, &static_sensor->linearity);
+					sscanf(line, "%19s %f %f", tmp, &static_sensor->offset, &static_sensor->linearity);
 				}
 				
 				// check for tek_sensor
 				if (strcmp(tmp,"tek_sensor") == 0)
 				{
 					// get config data for tek sensor
-					sscanf(line, "%69s %f %f", tmp, &tek_sensor->offset, &tek_sensor->linearity);	
+					sscanf(line, "%19s %f %f", tmp, &tek_sensor->offset, &tek_sensor->linearity);	
 				}
 				
 				// check for dynamic_sensor
 				if (strcmp(tmp,"dynamic_sensor") == 0)
 				{
 					// get config data for dynamic sensor
-					sscanf(line, "%69s %f %f", tmp, &dynamic_sensor->offset, &dynamic_sensor->linearity);
+					sscanf(line, "%19s %f %f", tmp, &dynamic_sensor->offset, &dynamic_sensor->linearity);
 				}
 				
 				// check for vario config
 				if (strcmp(tmp,"vario_config") == 0)
 				{
 					// get config data for dynamic sensor
-					sscanf(line, "%69s %f", tmp, &config->vario_x_accel);
+					sscanf(line, "%19s %f", tmp, &config->vario_x_accel);
 				}
 				
 				// check for voltage sensor config
 				if (strcmp(tmp,"voltage_config") == 0)
 				{
 					// get config data for dynamic sensor
-				        sscanf(line, "%69s %f %f", tmp, &voltage_sensor->scale,&voltage_sensor->offset);
+				        sscanf(line, "%19s %f %f", tmp, &voltage_sensor->scale,&voltage_sensor->offset);
 				        voltage_sensor->scale=1.0/voltage_sensor->scale;
 				}
 			}

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -106,7 +106,8 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 				if (strcmp(tmp,"voltage_config") == 0)
 				{
 					// get config data for dynamic sensor
-					sscanf(line, "%s %f", tmp, &voltage_sensor->voltage_factor);
+				        sscanf(line, "%s %f %f", tmp, &voltage_sensor->voltage_factor[0],&voltage_sensor->voltage_factor[1]);
+				        voltage_sensor->voltage_factor[0]=1.0/voltage_sensor->voltage_factor[0];
 				}
 			}
 	

--- a/sensorcal.c
+++ b/sensorcal.c
@@ -81,6 +81,7 @@ int main (int argc, char **argv) {
 	int result;
 	int c;
 	int i;
+	char sn[7];
 	char zero[1]={0x00};
 	
 	
@@ -107,7 +108,8 @@ int main (int argc, char **argv) {
 		printf("No EEPROM found !!\n");
 		exit(1);
 	}
-		
+
+	sn[6]=0;
 	// check commandline arguments
 	while ((c = getopt (argc, argv, "his:cde")) != -1)
 	{
@@ -124,7 +126,7 @@ int main (int argc, char **argv) {
 				}
 				strcpy(data.header, "OV");
 				data.data_version = EEPROM_DATA_VERSION;
-				strcpy(data.serial, "000000");
+				memset(data.serial,'0',6);
 				data.zero_offset=0.0;
 				update_checksum(&data);
 				printf("Writing data to EEPROM ...\n");
@@ -167,9 +169,10 @@ int main (int argc, char **argv) {
 				printf("Reading EEPROM values ...\n\n");
 				if( eeprom_read_data(&eeprom, &data) == 0)
 				{
+				  memcpy(sn,data.serial,6);
 					printf("Actual EEPROM values:\n");
 					printf("---------------------\n");
-					printf("Serial: \t\t\t%s\n", data.serial);
+					printf("Serial: \t\t\t%s\n", sn);
 					printf("Differential pressure offset:\t%f\n",data.zero_offset);
 				}
 				else
@@ -189,13 +192,12 @@ int main (int argc, char **argv) {
 					// read actual EEPROM values	
 					if( eeprom_read_data(&eeprom, &data) == 0)
 					{
-						for(i=0; i<7;i++)
+						for(i=0; i<6;i++)
 						{
-							data.serial[i]=*optarg;
+							sn[i]=data.serial[i]=*optarg;
 							optarg++;
 						}
-						data.serial[7]='\n';
-						printf("New Serial number: %s\n",data.serial);
+						printf("New Serial number: %s\n",sn);
 						update_checksum(&data);
 						printf("Writing data to EEPROM ...\n");
 						result = eeprom_write(&eeprom, (char*)&data, 0x00, sizeof(data));


### PR DESCRIPTION
This change modifies the current ads1110 code to add in an optional offset parameter read in the voltage_config line in sensord.conf.  If the parameter is missing it defaults to a value of 0, and so is completely backward compatible with the current .conf file.  The hardware has an offset and so it is impossible to calculate an accurate voltage without this offset value.  This also immediately takes the reciprocal of the scaling factor read in, and then multiplies by the reciprocal instead of dividing -- presumably a minor speed up.  This has been tested and works.