### PR TITLE
Format NMEA messages according to NMEA 0183

### DIFF
--- a/main.c
+++ b/main.c
@@ -171,8 +171,7 @@ int NMEA_message_handler(int sock)
 				}	
 			
 				// Send NMEA string via socket to XCSoar
-                                // send complete sentence including terminating '\0'
-				if ((sock_err = send(sock, s, strlen(s)+1, 0)) < 0)
+				if ((sock_err = send(sock, s, strlen(s), 0)) < 0)
 				{	
 					fprintf(stderr, "send failed\n");
 					break;
@@ -195,8 +194,7 @@ int NMEA_message_handler(int sock)
 				}	
 				
 				// Send NMEA string via socket to XCSoar
-                                // send complete sentence including terminating '\0'
-				if ((sock_err = send(sock, s, strlen(s)+1, 0)) < 0)
+				if ((sock_err = send(sock, s, strlen(s), 0)) < 0)
 				{	
 					fprintf(stderr, "send failed\n");
 					break;
@@ -216,8 +214,7 @@ int NMEA_message_handler(int sock)
 				}	
 				
 				// Send NMEA string via socket to XCSoar
-                                // send complete sentence including terminating '\0'
-				if ((sock_err = send(sock, s, strlen(s)+1, 0)) < 0)
+				if ((sock_err = send(sock, s, strlen(s), 0)) < 0)
 				{	
 					fprintf(stderr, "send failed\n");
 					break;

--- a/nmea.c
+++ b/nmea.c
@@ -82,7 +82,7 @@ int Compose_Pressure_POV_slow(char *sentence, float static_pressure, float dynam
 	length = sprintf(sentence, "$POV,P,%+07.2f,Q,%+05.2f", static_pressure, (dynamic_pressure)); 
 	
 	// Calculate NMEA checksum and add to string
-	sprintf(sentence + length, "*%02X\n", NMEA_checksum(sentence));
+	sprintf(sentence + length, "*%02X\r\n", NMEA_checksum(sentence));
 	
 	//print sentence for debug
 	debug_print("POV slow NMEA sentence: %s\n", sentence);
@@ -129,7 +129,7 @@ int Compose_Pressure_POV_fast(char *sentence, float te_vario)
 	length = sprintf(sentence, "$POV,E,%+05.2f", te_vario); 
 	
 	// Calculate NMEA checksum and add to string
-	sprintf(sentence + length, "*%02X\n", NMEA_checksum(sentence));
+	sprintf(sentence + length, "*%02X\r\n", NMEA_checksum(sentence));
 	
 	//print sentence for debug
 	debug_print("NMEA sentence: %s\n", sentence);
@@ -176,7 +176,7 @@ int Compose_Voltage_POV(char *sentence, float voltage)
 	length = sprintf(sentence, "$POV,V,%+05.2f", voltage); 
 	
 	// Calculate NMEA checksum and add to string
-	sprintf(sentence + length, "*%02X\n", NMEA_checksum(sentence));
+	sprintf(sentence + length, "*%02X\r\n", NMEA_checksum(sentence));
 	
 	//print sentence for debug
 	debug_print("NMEA sentence: %s\n", sentence);


### PR DESCRIPTION
Protocol requires messages to end with `<CR><LF` bytes.

This effectively reverts #6, bit makes XCSoar understand NMEA stream produced by sensord again.