### PR TITLE
Added Temperature Sensor Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #Some compiler stuff and flags
 CFLAGS += -g -Wall
 EXECUTABLE = sensord sensorcal
-_OBJ = ms5611.o ams5915.o ads1110.o main.o nmea.o timer.o KalmanFilter1d.o cmdline_parser.o configfile_parser.o vario.o AirDensity.o 24c16.o
+_OBJ = ms5611.o ams5915.o ads1110.o main.o nmea.o timer.o KalmanFilter1d.o cmdline_parser.o configfile_parser.o vario.o AirDensity.o 24c16.o ds2482.o
 _OBJ_CAL = 24c16.o ams5915.o sensorcal.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 OBJ_CAL = $(patsubst %,$(ODIR)/%,$(_OBJ_CAL))

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -123,10 +123,9 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 				  // get config data for temperature sensor
 				  sscanf(line, "%19s %d", tmp, &temp_sensor->databits);
 				  if ((temp_sensor->databits<9) || (temp_sensor->databits>12)) {
-				    printf ("Temp sensor databits (%d) is not valid, must be in the range of 9-12.  Using default value.\n",temp_sensor->databits);
+				    printf ("Temp sensor databits (%d) is not valid, must be in the range of 9-12.  Using default value of 10 bits.\n",temp_sensor->databits);
 				    temp_sensor->databits=10;
 				  }
-				  printf ("Read in Config data %d\n",temp_sensor->databits);
 				}
 			}
 	

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -26,12 +26,13 @@
 #include "ms5611.h"
 #include "ams5915.h"
 #include "ads1110.h"
+#include "ds2482.h"
 #include "configfile_parser.h"
 
 extern int g_debug;
 extern FILE *fp_console;
 
-int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_ams5915 *dynamic_sensor, t_ads1110 *voltage_sensor, t_config *config)
+int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_ams5915 *dynamic_sensor, t_ads1110 *voltage_sensor, t_ds2482 *temp_sensor, t_config *config)
 {
 	char line[70];
 	char tmp[20];
@@ -71,7 +72,14 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 				if (strcmp(tmp,"output_POV_V") == 0)
 				{	
 					config->output_POV_V= 1;
-					//printf("OUTput POV_P_Q enabled !! \n");
+					//printf("OUTput POV_V enabled !! \n");
+				}
+
+				// check for output of POV_T sentence
+				if (strcmp(tmp,"output_POV_T") == 0)
+				{	
+					config->output_POV_T= 1;
+					//printf("OUTput POV_T enabled !! \n");
 				}
 				
 				// check for static_sensor
@@ -108,6 +116,17 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 					// get config data for dynamic sensor
 				        sscanf(line, "%19s %f %f", tmp, &voltage_sensor->scale,&voltage_sensor->offset);
 				        voltage_sensor->scale=1.0/voltage_sensor->scale;
+				}
+
+				// check for temp config
+				if (strcmp(tmp,"temp_config") == 0) {
+				  // get config data for temperature sensor
+				  sscanf(line, "%19s %d", tmp, &temp_sensor->databits);
+				  if ((temp_sensor->databits<9) || (temp_sensor->databits>12)) {
+				    printf ("Temp sensor databits (%d) is not valid, must be in the range of 9-12.  Using default value.\n",temp_sensor->databits);
+				    temp_sensor->databits=10;
+				  }
+				  printf ("Read in Config data %d\n",temp_sensor->databits);
 				}
 			}
 	

--- a/configfile_parser.h
+++ b/configfile_parser.h
@@ -21,7 +21,8 @@ typedef struct {
 	char output_POV_E;
 	char output_POV_P_Q;
 	char output_POV_V;
+        char output_POV_T;
 	float vario_x_accel;
 } t_config;
 
-int cfgfile_parser(FILE *, t_ms5611 *, t_ms5611 *, t_ams5915 *, t_ads1110 *, t_config *);
+int cfgfile_parser(FILE *, t_ms5611 *, t_ms5611 *, t_ams5915 *, t_ads1110 *, t_ds2482 *,t_config *);

--- a/ds2482.c
+++ b/ds2482.c
@@ -1,0 +1,461 @@
+/*  
+    sensord - Sensor Interface for XCSoar Glide Computer - http://www.openvario.org/
+    Copyright (C) 2014  The openvario project
+    A detailed list of copyright holders can be found in the file "AUTHORS" 
+
+    This program is free software; you can redistribute it and/or 
+    modify it under the terms of the GNU General Public License 
+    as published by the Free Software Foundation; either version 3
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <http://www.gnu.org/licenses/>.	
+*/
+
+#include "ds2482.h"
+#include <time.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <math.h>
+#include <time.h>
+#include <linux/i2c-dev.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include "def.h"
+
+extern int g_debug;
+extern FILE *fp_console;
+
+//http://datasheets.maximintegrated.com/en/ds/DS2482-100.pdf
+//http://datasheets.maximintegrated.com/en/ds/DS18B20.pdf
+//http://www.wulfden.org/downloads/datasheets/DS2482_AN3684.pdf
+
+// The routines in this code were roughly lifted from https://pastebin.com/0d93ZuRb
+// Those assume the use of the Search and Match ROM.  As such a number of
+// functions are included that are not needed if a Skip ROM is used which
+// is adequate, and faster if only a single 1 Wire device is present.
+
+int ds2482_open(t_ds2482 *sensor, unsigned char i2c_address)
+{
+	// local variables
+	int fd;
+	
+	// try to open I2C Bus
+	fd = open("/dev/i2c-1", O_RDWR);
+	
+	if (fd < 0) {
+	   fprintf(stderr, "Error opening file: %s\n", strerror(errno));
+	   return 1;
+	}
+
+	if (ioctl(fd, I2C_SLAVE, i2c_address) < 0) {
+           fprintf(stderr, "ioctl error: %s\n", strerror(errno));
+	   return 1;
+	}
+	
+	if (g_debug > 0) printf("Opened DS2482 on 0x%x\n", i2c_address);
+	
+	//assign file handle to sensor object
+	sensor->fd = fd;
+	sensor->address = i2c_address;
+	return (0);
+}
+
+int ds2482_reset(t_ds2482 *sensor) {
+    //server.log(format("Function: Resetting DS2482 at %i (%#x)", I2CAddr, I2CAddr));
+    write(sensor->fd, "\xf0", 1); //reset DS2482
+    sensor->owDeviceAddress[0]=0;
+    sensor->owDeviceAddress[1]=0;
+    sensor->owTriplet=4;
+    sensor->owLastDevice=0; 
+    sensor->owLastDiscrepancy=0;
+    sensor->active=0;
+    sensor->valid=0;
+    sensor->temperature=23;
+    return 1;
+}
+
+int OWReset(t_ds2482 *sensor) {
+    int i;
+    unsigned char data;
+    
+    //server.log("Function: I2C Reset");
+    if (write(sensor->fd, "\xb4",1)!=1) { //1-wire reset
+        //Device failed to acknowledge reset
+        //server.log("I2C Reset Failed");
+        return 0;
+    }
+    for (i=0;i<100;++i) {
+        if (read(sensor->fd,&data,1)==0) { //Read the status register
+            //server.log("I2C Read Status Failed");
+            return 0;
+        } else {
+            //server.log(format("Read Status Byte = %d", data[0]));
+            if (data & 1) { // 1-Wire Busy bit
+                usleep(1000); //Wait, try again
+            } else {
+                //server.log("One-Wire bus is idle");
+                if (data & 4) { //Short Detected bit
+                   //server.log("One-Wire Short Detected");
+                   return 0;
+                }
+                if (data & 2) { //Presense-Pulse Detect bit
+                   //server.log("One-Wire Devices Found");
+		   return 1;
+                } else {
+                   //server.log("No One-Wire Devices Found");
+                   return 0;
+                }
+            }
+        }
+    }
+    //server.log("One-Wire busy too long");
+    return 0;
+}
+
+int OWWriteByte(t_ds2482 *sensor, unsigned char writeval) {
+    int i;
+    unsigned char data[2];
+	
+    //server.log("Function: Write Byte to One-Wire");
+    if (write(sensor->fd,"\xe1\xf0",2)!=2) { //Device failed to acknowledge
+       //server.log("I2C Write Failed");
+       return -1;
+    }
+    for (i=0;i<100;++i) {
+	if (read(sensor->fd,data,1)==0) { //Read the status register
+           //server.log("I2C Read Status Failed");
+           return -1;
+        } else {
+           //server.log(format("Read Status Byte = %d", data[0]));
+           if (data[0] & 0x01) { // 1-Wire Busy bit
+              //server.log("One-Wire bus is busy");
+      	      usleep(1000);//Wait, try again
+           } else {
+              //server.log("One-Wire bus is idle");
+              break;
+           }
+        }
+    }
+    if (i == 100) {
+       //server.log("One-Wire busy for too long");
+       return -1;
+    }
+    data[0]=0xa5;
+    data[1]=writeval;    
+    if (write(sensor->fd,data,2)!=2) { //set write byte command (A5) and send data (byte)
+       //Device failed to acknowledge
+       //server.log(format("I2C Write Byte Failed. Data: %#.2X", byte));
+       return -1;
+     }
+     for (i=0;i<100;++i) {
+         if (read(sensor->fd,data,1)==0) { //Read the status register
+            //server.log("I2C Read Status Failed");
+            return -1;
+         } else {
+            //server.log(format("Read Status Byte = %d", data[0]));
+            if (data[0] & 1) { // 1-Wire Busy bit
+                //server.log("One-Wire bus is busy");
+                usleep(1000); //Wait, try again
+            } else {
+                //server.log("One-Wire bus is idle");
+                break;
+            }
+         }
+    }
+    if (i == 100) {
+       //server.log("One-Wire busy for too long");
+       return -1;
+    }
+	
+    //server.log("One-Wire Write Byte complete");
+    return 0;
+}
+
+int OWReadByte(t_ds2482 *sensor) {
+    int i;
+    unsigned char data;
+	
+    //See if the 1wire bus is idle
+    //server.log("Function: Read Byte from One-Wire");
+    if (write(sensor->fd,"\xe1\xf0",2)!=2) { //Device failed to acknowledge
+        //server.log("I2C Write Failed");
+        return -1;
+    }
+    for (i=0;i<100;++i) {
+       if (read(sensor->fd,&data,1)==0) { //Read the status register
+          //server.log("I2C Read Status Failed");
+          return -1;
+       } else {
+	  //server.log(format("Read Status Byte = %d", data));
+          if (data & 0x01) { // 1-Wire Busy bit
+             //server.log("One-Wire bus is busy");
+             usleep(1000); //Wait, try again
+          } else {
+             //server.log("One-Wire bus is idle");
+             break;
+          }
+       }  
+    }
+    if (i== 100) {
+      //server.log("One-Wire busy for too long");
+      return -1;
+    }
+    //Send a read command, then wait for the 1wire bus to finish
+    if (write(sensor->fd,"\x96",1)!=1) { //Device failed to acknowledge
+       //server.log("I2C Write Read-Request Failed");
+       return -1;
+    }
+    for (i=0;i<100;++i) {
+       if (read(sensor->fd,&data,1)==0) { //Read the status register
+          //server.log("I2C Read Status Failed");
+          return -1;
+       } else {
+            //server.log(format("Read Status Byte = %d", data));
+            if (data & 1) { // 1-Wire Busy bit
+                //server.log("One-Wire bus is busy");
+                usleep(1000); //Wait, try again
+            } else {
+                //server.log("One-Wire bus is idle");
+                break;
+            }
+        }  
+    }
+    if (i==100) {
+       //server.log("One-Wire busy for too long");
+       return -1;
+    }
+    
+    //Go get the data byte
+    if (write(sensor->fd,"\xe1\xe1",2)!=2) { //Device failed to acknowledge
+       //server.log("I2C Write Failed");
+       return -1;
+    }
+    if (read(sensor->fd,&data,1)==0) { //Read the status register
+       //server.log("I2C Read Status Failed");
+       return -1;
+    } 
+    return data;
+}
+
+int OWTriplet(t_ds2482 *sensor) {
+    unsigned char data[2]={0x78,0};
+    int i;
+    
+    //server.log("Function: OneWire Triplet");
+    data[1]=sensor->owTriplet<<5;
+    if (write(sensor->fd,data,2)!=2) { //Device failed to acknowledge
+        //server.log("OneWire Triplet  Failed");
+        return 0;
+    }
+    for (i=0;i<100;++i) {
+	if (read(sensor->fd,&data,1)==0) { //Read the status register
+            //server.log("I2C Read Status Failed");
+            return 0;
+        } else {
+            //server.log(format("Read Status Byte = %d", data[0]));
+            if (data[0] & 1) { // 1-Wire Busy bit
+                //server.log("One-Wire bus is busy");
+                usleep(1000); //Wait, try again
+            } else {
+                //server.log("One-Wire bus is idle");
+                sensor->owTriplet=(data[0]>>5)&7;            
+                return 1;
+            }
+        }
+    }
+    if (i== 100) {
+       //server.log("One-Wire busy for too long");
+       return 0;
+    }
+    return 1;
+}
+
+// The following function is unused and untested
+
+int OWSearch(t_ds2482 *sensor) {
+    //server.log("Function: OneWire Search");
+
+    int deviceAddress4ByteMask = 1;
+
+    sensor->active=0;
+    if (sensor->owLastDevice) {
+        //server.log("OneWire Search Complete");
+        sensor->owLastDevice = 0;
+        sensor->owLastDiscrepancy = 0;
+        sensor->owDeviceAddress[0] = 0xFFFFFFFF;
+        sensor->owDeviceAddress[1] = 0xFFFFFFFF;
+    }
+    if (!sensor->owLastDevice) { //if the last call was not the last one
+        if (!OWReset(sensor)) { //if there are no parts on 1-wire, return false
+            sensor->owLastDiscrepancy = 0;
+            return 0;
+        }
+	int bitNumber = 1;
+	int lastZero = 0;
+        int deviceAddress4ByteIndex = 0; //Fill last 4 bytes first, data from onewire comes LSB first.
+
+        OWWriteByte(sensor, 0xF0); //Issue the Search ROM command        
+        do { // loop to do the search
+            if (bitNumber < sensor->owLastDiscrepancy) {
+                if (sensor->owDeviceAddress[deviceAddress4ByteIndex] & deviceAddress4ByteMask) 
+                    sensor->owTriplet |= 4;  else sensor->owTriplet &= 3;
+            } else if (bitNumber == sensor->owLastDiscrepancy) //if equal to last pick 1, if not pick 0
+                sensor->owTriplet |= 4; else sensor->owTriplet &= 3;
+            
+            if (!OWTriplet(sensor)) return 0;
+            
+            //if 0 was picked then record its position in lastZero
+            if (sensor->owTriplet==0) lastZero = bitNumber;
+            
+            //check for no devices on 1-wire
+            if ((sensor->owTriplet&3)==3) break;
+            
+            //set or clear the bit in the SerialNum byte serial_byte_number with mask
+            if (sensor->owTriplet&4) 
+	       sensor->owDeviceAddress[deviceAddress4ByteIndex] |= deviceAddress4ByteMask;
+            else 
+                sensor->owDeviceAddress[deviceAddress4ByteIndex] &= ~deviceAddress4ByteMask;
+            bitNumber++; //increment the byte counter bit number
+            deviceAddress4ByteMask <<=  1; //shift the bit mask left
+            
+            if (!deviceAddress4ByteMask) { //if the mask is 0 then go to other address block and reset mask to first bit
+                deviceAddress4ByteIndex++;
+                deviceAddress4ByteMask = 1;
+            }
+	} while (deviceAddress4ByteIndex <2);
+
+        if (bitNumber == 65) { //if the search was successful then
+            sensor->owLastDiscrepancy = lastZero;
+            if (sensor->owLastDiscrepancy==0) sensor->owLastDevice = 1; else sensor->owLastDevice = 0;
+            //server.log(format("OneWire Device Address = %.8X%.8X", owDeviceAddress[1], owDeviceAddress[0]));
+            if (OWCheckCRC(sensor)) { 
+	       if ((sensor->owDeviceAddress[0] & 0xff) == 0x28) {
+		  sensor->active=1; return 1; } else {
+                  //server.log("OneWire device address CRC check failed");
+                  return 1;
+               }
+	    }
+            
+        }
+    }
+    //server.log("No One-Wire Devices Found, Resetting Search");
+    sensor->owLastDiscrepancy = 0;
+    sensor->owLastDevice = 0;
+    return 0;
+}
+
+// The following function is unused and untested (and probably should be an inline function
+
+int OWCheckCRC(t_ds2482 *sensor) {
+    int crc, j,i;
+	long int da32bit;
+	
+	for (i=0;i<2;i++) {
+       for(j=0,crc=0,da32bit=sensor->owDeviceAddress[i]; j<4; j++) { //All four bytes
+           crc = AddCRC(da32bit & 0xFF, crc);
+           //server.log(format("CRC = %.2X", crc));
+           da32bit >>= 8; //Shift right 8 bits
+       }
+	}
+    //server.log(format("CRC = %#.2X", crc));
+    //server.log(format("DA  = %#.2X", da32bit));
+    if ((da32bit & 0xFF) == crc) { //last byte of address should match CRC of other 7 bytes
+        //server.log("CRC Passed");
+        return 1; //match
+    }
+    return 0; //bad CRC
+}
+
+// The following function is unused and untested (and probably should be an
+// inline function
+
+int  AddCRC(int inbyte, int crc) {
+    int i;
+	
+    for(i=0; i<8; i++) {
+        if ((crc ^ inbyte) & 0x01) crc=(crc>>1)^0x8c; else crc>>=1;
+        inbyte >>= 1;
+    }
+    return crc;
+}
+
+// The following function is unused untested
+
+int OWSelect(t_ds2482 *sensor) {
+    //server.log("Selecting device");
+      int i,j;
+	
+     if (OWWriteByte(sensor, 0x4C)==-1) return 0; //Issue the Match ROM command
+     for(i=0; i<2; i++) {
+        long int da32bit = sensor->owDeviceAddress[i];
+        for(j=0; j<4; j++) {
+            //server.log(format("Writing byte: %.2X", da32bit & 0xFF));
+            OWWriteByte(sensor, da32bit & 0xff); //Send lowest byte
+            da32bit >>=  8; //Shift right 8 bits
+        }
+     }
+     return 1;
+}
+int OWConfigureBits (t_ds2482 *sensor) {
+	unsigned char data[4] = {0x4e,0x00,0x00,0x7f};
+	int i,j;
+	
+	if (!OWReset(sensor)) return 0;
+	if (OWWriteByte(sensor,0xCC)==-1) return 0;
+	
+	switch (sensor->databits) {
+		case 9  : data[3]=0x1f; sensor->rollover = 8; break;
+		case 10 : data[3]=0x3f; sensor->rollover = 15; break;
+                case 11 : data[3]=0x5f; sensor->rollover = 30; break;
+                default : sensor->rollover = 60; break;
+	}
+	for (i=0,j=1;i<4;++i) 
+	   if (OWWriteByte(sensor,data[i])==-1) j=0;	 
+	return j;
+}		
+
+int OWReadTemperature(t_ds2482 *sensor) {
+    int data[5];
+    int i,j;
+
+    sensor->valid=0;
+    for(i=0,j=0; i<5; i++) { //we only need 5 of the bytes
+        //Technically we only need two, but grabbing 5 lets us double check the configuration
+        data[i] = OWReadByte(sensor);
+	if (data[i]<0)  j=1;
+        //server.log(format("read byte: %.2X", data[i]));
+    }
+    if (j) return 0;
+    j=1;
+    i = (data[1] << 8) | data[0];
+	switch (data[4]&0x60) {
+	   case 0x60 : //server.log("12 bit resolution"); //750 ms conversion time
+	               sensor->temperature=i/16.0;
+                       if (sensor->databits!=12) j=2;
+		       break;
+	   case 0x40 : //server.log("11 bit resolution"); //375 ms
+                       sensor->temperature=(i>>1)/8.0;
+                       if (sensor->databits!=11) j=2;
+		       break;
+	   case 0x20 : //server.log("10 bit resolution"); //187.5 ms
+                       sensor->temperature=(i>>2)/4.0;
+                       if (sensor->databits!=10) j=2;
+		       break;
+	   default   : //server.log("9 bit resolution"); //93.75 ms	        
+                       sensor->temperature=(i>>3)/2.0;
+		       if (sensor->databits!=9) j=2;
+    }
+    if ((sensor->temperature<125) && (sensor->temperature>-55)) sensor->valid=1; else j=0;
+	
+    //server.log(format("Temperature = %.1f °C", celsius));
+    debug_print("%s @ 0x18: temperature %f\n",__func__,sensor->temperature);
+    return j;
+}

--- a/ds2482.c
+++ b/ds2482.c
@@ -77,7 +77,7 @@ int ds2482_reset(t_ds2482 *sensor) {
   sensor->owTriplet=4;
   sensor->owLastDevice=0;
   sensor->owLastDiscrepancy=0;
-  sensor->active=0;
+  sensor->present=0;
   sensor->valid=0;
   sensor->temperature=23;
   return 1;
@@ -296,7 +296,7 @@ int OWSearch(t_ds2482 *sensor) {
 
     int deviceAddress4ByteMask = 1;
 
-    sensor->active=0;
+    sensor->present=0;
     if (sensor->owLastDevice) {
         //server.log("OneWire Search Complete");
         sensor->owLastDevice = 0;
@@ -349,7 +349,7 @@ int OWSearch(t_ds2482 *sensor) {
             //server.log(format("OneWire Device Address = %.8X%.8X", owDeviceAddress[1], owDeviceAddress[0]));
             if (OWCheckCRC(sensor)) { 
 	       if ((sensor->owDeviceAddress[0] & 0xff) == 0x28) {
-		  sensor->active=1; return 1; } else {
+		  sensor->present=1; return 1; } else {
                   //server.log("OneWire device address CRC check failed");
                   return 1;
                }
@@ -427,10 +427,10 @@ int OWConfigureBits (t_ds2482 *sensor) {
 	if (OWWriteByte(sensor,0xCC)==-1) return 0;
 	
 	switch (sensor->databits) {
-		case 9  : data[3]=0x1f; sensor->rollover = 8; break;
-		case 10 : data[3]=0x3f; sensor->rollover = 15; break;
-                case 11 : data[3]=0x5f; sensor->rollover = 30; break;
-                default : sensor->rollover = 60; break;
+	case 9  : data[3]=0x1f; sensor->conversion_time = 6; sensor->delta_conversion_time = 5; break;
+	case 10 : data[3]=0x3f; sensor->conversion_time = 13; sensor->delta_conversion_time = 5;  break;
+	case 11 : data[3]=0x5f; sensor->conversion_time = 28; sensor->delta_conversion_time = 5; break;
+	default : sensor->conversion_time = 58; sensor->delta_conversion_time = 5; break; 
 	}
 	for (i=0,j=1;i<4;++i) 
 	   if (OWWriteByte(sensor,data[i])==-1) j=0;	 
@@ -475,7 +475,6 @@ int OWReadTemperature(t_ds2482 *sensor) {
 		       if (sensor->databits!=9) j=2;
     }
 	if ((sensor->temperature<125) && (sensor->temperature>-55)) sensor->valid=1; else j=0;
-	
     //server.log(format("Temperature = %.1f °C", celsius));
     debug_print("%s @ 0x18: temperature %f\n",__func__,sensor->temperature);
     return j;

--- a/ds2482.h
+++ b/ds2482.h
@@ -1,0 +1,49 @@
+
+/*  
+	sensord - Sensor Interface for XCSoar Glide Computer - http://www.openva
+rio.org/
+    Copyright (C) 2014  The openvario project
+    A detailed list of copyright holders can be found in the file "AUTHORS" 
+
+    This program is free software; you can redistribute it and/or 
+    modify it under the terms of the GNU General Public License 
+    as published by the Free Software Foundation; either version 3
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <http://www.gnu.org/licenses/>.	
+*/
+
+// define struct for DS2482 sensor
+
+typedef struct {
+   int fd;
+   unsigned char address;
+   unsigned long int owDeviceAddress[2]; // should init to 0
+   int owTriplet; // Should be init to 4
+   int owLastDevice; // should init to 0
+   int owLastDiscrepancy; // should init to 0
+   float temperature;
+   int active;
+   int valid;
+   int rollover;
+   int databits;
+} t_ds2482;
+
+int ds2482_open(t_ds2482 *, unsigned char);
+int ds2482_reset(t_ds2482 *);
+int OWReset(t_ds2482 *);
+int OWWriteByte(t_ds2482 *, unsigned char);
+int OWReadByte(t_ds2482 *);
+int OWTriplet(t_ds2482 *);
+int OWSearch(t_ds2482 *);
+int OWCheckCRC(t_ds2482 *);
+int AddCRC(int, int);
+int OWSelect(t_ds2482 *);
+int OWConfigureBits (t_ds2482 *);
+int OWReadTemperature(t_ds2482 *);

--- a/ds2482.h
+++ b/ds2482.h
@@ -29,9 +29,10 @@ typedef struct {
    int owLastDevice; // should init to 0
    int owLastDiscrepancy; // should init to 0
    float temperature;
-   int active;
+   int present;
    int valid;
-   int rollover;
+  int conversion_time;
+  int delta_conversion_time;
    int databits;
 } t_ds2482;
 

--- a/nmea.c
+++ b/nmea.c
@@ -215,14 +215,14 @@ int Compose_Temperature_POV(char *sentence, float temperature)
   // check voltage input value for validity
   if ((temperature < -55) || (temperature > 125)) {
     temperature = 23;
-    success = 0;
+    success = 10;
   }
 
   // compose NMEA String
   length = sprintf(sentence, "$POV,T,%+05.4f", temperature); 
 
   // Calculate NMEA checksum and add to string
-  sprintf(sentence + length, "*%02X\n", NMEA_checksum(sentence));
+  sprintf(sentence + length, "*%02X\rn", NMEA_checksum(sentence));
 
   //print sentence for debug
   debug_print("NMEA sentence: %s\n", sentence);

--- a/nmea.c
+++ b/nmea.c
@@ -184,6 +184,52 @@ int Compose_Voltage_POV(char *sentence, float voltage)
 }
 
 /**
+* @brief Implements the $POV NMEA Sentence for voltage data
+* @param sentence char pointer for created string
+* @param Battery Voltage
+* @return result
+* 
+* Implementation of the properitary NMEA sentence for AKF Glidecomputer
+* \n
+*
+*     $POV,T,Temperature*CRC
+*       |  |      |       |
+*       1  2      3       4
+*
+*     1: $P            		Properitary NMEA Sentence
+*        OV         		Manufacturer Code: OpenVario
+*
+*     2: T               	Code for Temperature in C
+*     
+*     3: Temperature        Format: 27.125
+*
+* @date 13.03.2016 born
+*
+*/ 
+
+int Compose_Temperature_POV(char *sentence, float temperature)
+{
+  int length;
+  int success = 1;
+
+  // check voltage input value for validity
+  if ((temperature < -55) || (temperature > 125)) {
+    temperature = 23;
+    success = 0;
+  }
+
+  // compose NMEA String
+  length = sprintf(sentence, "$POV,T,%+05.4f", temperature); 
+
+  // Calculate NMEA checksum and add to string
+  sprintf(sentence + length, "*%02X\n", NMEA_checksum(sentence));
+
+  //print sentence for debug
+  debug_print("NMEA sentence: %s\n", sentence);
+  return (success);
+}
+
+/**
 * @brief Implements the NMEA Checksum
 * @param char* NMEA string
 * @return int Calculated Checksum for string

--- a/nmea.c
+++ b/nmea.c
@@ -222,7 +222,7 @@ int Compose_Temperature_POV(char *sentence, float temperature)
   length = sprintf(sentence, "$POV,T,%+05.4f", temperature); 
 
   // Calculate NMEA checksum and add to string
-  sprintf(sentence + length, "*%02X\rn", NMEA_checksum(sentence));
+  sprintf(sentence + length, "*%02X\r\n", NMEA_checksum(sentence));
 
   //print sentence for debug
   debug_print("NMEA sentence: %s\n", sentence);

--- a/nmea.h
+++ b/nmea.h
@@ -24,5 +24,6 @@ unsigned char NMEA_checksum(char *);
 int Compose_Pressure_POV_slow(char *, float, float);
 int Compose_Pressure_POV_fast(char *, float);
 int Compose_Voltage_POV(char *sentence, float voltage);
+int Compose_Temperature_POV(char *sentence, float temperature);
 
 #endif


### PR DESCRIPTION
Let's try this again from a fresh starting point.

This pull request adds support for the DS18B20 temperature sensor, which was already supported in hardware, but not software.

It adds two parameters in the sensord.conf:
output_POV_T which turns on the sentences (just like the other output parameters)
temp_config <9|10|11|12> This selects how many bits the user wants to use.  9 bits gives .5 degree  C resolution, 12 bits gives .0625 degree C resolution.  Conversion time is inversely proportional to resolution.  TANSTAAFL.

The code assumes that only a single DS18B20 is attached to the one-wire interface.  If more (or different devices) are plugged in, bad behavior may result.  Code is included, but is unused and untested to support multiple devices.