### PR TITLE
Multiple changes to improve noise performance

### DIFF
--- a/ms5611.h
+++ b/ms5611.h
@@ -34,6 +34,7 @@ typedef struct {
 	uint16_t C6;
 	uint32_t D1;
 	uint32_t D2;
+	uint32_t D2f;
 	int32_t dT;
 	int32_t temp;
 	int64_t off;
@@ -53,7 +54,8 @@ int ms5611_measure(t_ms5611 *);
 int ms5611_calculate(t_ms5611 *);
 int ms5611_open(t_ms5611 *, unsigned char);
 
+int ms5611_calculate_pressure(t_ms5611 *);
 int ms5611_read_pressure(t_ms5611 *);
-int ms5611_read_temp(t_ms5611 *);
+int ms5611_read_temp(t_ms5611 *, int);
 int ms5611_start_temp(t_ms5611 *);
 int ms5611_start_pressure(t_ms5611 *);


### PR DESCRIPTION
This is a major code change in main.c and a somewhat lesser one in ms5611.c/ms5611.h

All code changes are designed to improve noise performance on the MS5611s... See Issue #23.

The following issues are addressed:

1) The sampling strategy has to be absolutely regular.  Therefore, running at the same 12.5ms interval alternates between temperature and pressure continuously.  The two sensors are run opposite each other, which is to say when one is sampling temperature, the other is sampling pressure.
2) The MS5611 is very sensitive to timing jitter in the > 1 ms regime.  Therefore, rather than simply doing a usleep (12500) as was previously done.  The real-time that the last conversion was started is recorded.  It then sleeps for previous time + 10500 us - current time.  Once it wakes up, it then repeatedly sleeps for 50 us until it's just past the correct time.
3) If, despite the steps in #2, we still overshoot the desired time, a compensation scheme is employed whereby we measure the change in D2 (temperature) value on the temperature sensor we were sampling and multiply that by K and then add that to D1.
4) If the glitch is large enough the output of the sensors is suppressed from getting into any of the filters, so the filters just retain their values.  The D2 filter ignores all new values until D2 approaches the value of filtered output (see #5)
5) An IIR filter was added to D2, similar to the filters on dynamic and static pressure.
6) The NMEA message handler was modified to put out a message every 4 time slots (there will be 2 static, 2 TE readings, and 4 dynamic readings between NMEA messaging).  All of these goes through a filter, and the output of the filter is decimated to produce approximately the same amount of messaging as in the old one.
7)  DeltaT going into the Kalman filter is measured rather than assumed, this should improve the performance of the Kalman filter slightly.
8) The MS5611 routines were slightly modified in the following ways:
a) Reading the pressure sensor and calculating the pressure (*scale + offset, x2) were split into separate functions.
b) Calculating the value of "sens" and "off" were moved into the temperature reading.  These are entirely defined by the temperature, so it makes no sense to update this every time we read pressure rather than every time we read temperature.  In theory, since we are alternating, it doesn't make any difference, but because of the glitch detection circuit, it is actually helpful to have moved it.
c) The read_temperature function only updates the D2 filter, sens and off if a timing glitch is not affecting the result of D2 -- but it still measures D2 in order to compensate D1, and to detect when the timing glitch has subsided.

This is a big change, and it needs to be beta tested.  PLEASE beta test this and try to find problems.  However, so far, I am amazed by the improvement.