### PR TITLE
Do not leave stdout closed in daemon mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -471,6 +471,7 @@ int main (int argc, char **argv) {
 		
 		//open file for log output
 		fp_console = fopen("sensord.log","w+");
+		stdout = fp_console;
 		stderr = fp_console;
 		setbuf(fp_console, NULL);
 	}


### PR DESCRIPTION
When sensord daemonizes, it closes stderr and stdout files. It then assigns stderr to be a log file. stdout is kept closed, however sensord still tries to output to it with regular `printf` statements.

This messes communication with `/dev/i2c-1 device`, which is being assigned file descriptor "1", typically used by stdout.

Assign stdout to log file, so that prints are routed to the right place.

Fixes #24.