### PR TITLE
Battery voltage in image-openvario is wrong

### DIFF
--- a/nmea.c
+++ b/nmea.c
@@ -166,9 +166,14 @@ int Compose_Voltage_POV(char *sentence, float voltage)
 	int success = 1;
 
 	// check voltage input value for validity
-	if ((voltage < 2.) || (voltage > 20.))
+	if (voltage < 2.)
 	{
 		voltage = 0.;
+		success = 10;
+	}
+    else if (voltage > 20.)
+	{
+		voltage = 99.9;
 		success = 10;
 	}
 	


### PR DESCRIPTION
in #145 of repository Openvario/meta-openvario was reported a wrong battery value in the XCSoar display,

The sensord version 0.3.4 show a factor of ~1.5 - and at an Overrun (> ~ 12,3V) a value of 0.0V ;-(!

With changes from Dan and hpmax in the master branch the value is correct in the sensord-testing!
This means we need a new tag version 0.3.5 of sensord immediately with complete changes or we have to rebase the testing stuff with the voltage calculation only...

