### PR TITLE
ms5611: make device bus and address configurable

### DIFF
--- a/compdata.c
+++ b/compdata.c
@@ -270,12 +270,16 @@ int main (int argc, char **argv) {
 	// initialize variables
 	static_sensor.offset = 0.0;
 	static_sensor.linearity = 1.0;
+	static_sensor.address = 0x76;
+	static_sensor.bus = 1;
 
 	tep_sensor.offset = 0.0;
 	tep_sensor.linearity = 1.0;
 	tep_sensor.Pcomp2 = static_sensor.Pcomp2 = -0.0000004638;
 	tep_sensor.Pcomp1 = static_sensor.Pcomp1 =  0.9514328801;
 	tep_sensor.Pcomp0 = static_sensor.Pcomp0 =  0.1658634996;
+	tep_sensor.address = 0x77;
+	tep_sensor.bus = 1;
 
 	config.timing_log  = 0.06666666666;
 	config.timing_mult = 50;
@@ -365,7 +369,7 @@ int main (int argc, char **argv) {
 	tio.c_lflag |= ICANON | ECHO;
 	tcsetattr( 0, TCSANOW, &tio );
 
-	if (ms5611_open(&static_sensor, 0x76) != 0)
+	if (ms5611_open(&static_sensor) != 0)
 	{
 		fprintf(stderr, "Open static sensor failed !!\n");
 		return 1;
@@ -379,8 +383,7 @@ int main (int argc, char **argv) {
 	static_sensor.valid = 1;
 
 	// open sensor for velocity pressure
-	/// @todo remove hardcoded i2c address for velocity pressure
-	if (ms5611_open(&tep_sensor, 0x77) != 0)
+	if (ms5611_open(&tep_sensor) != 0)
 	{
 		fprintf(stderr, "Open tep sensor failed !!\n");
 		return 1;

--- a/configfile_parser.c
+++ b/configfile_parser.c
@@ -91,7 +91,7 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 					if (strcmp(tmp,"static_sensor") == 0)
 					{
 						// get config data for static sensor
-						sscanf(line, "%19s %f %f", tmp, &static_sensor->offset, &static_sensor->linearity);
+						sscanf(line, "%19s %f %f %hhx %hhu", tmp, &static_sensor->offset, &static_sensor->linearity, &static_sensor->address, &static_sensor->bus);
 						static_sensor->offset*=16;
 					}
 
@@ -132,7 +132,7 @@ int cfgfile_parser(FILE *fp, t_ms5611 *static_sensor, t_ms5611 *tek_sensor, t_am
 					if (strcmp(tmp,"tek_sensor") == 0)
 					{
 						// get config data for tek sensor
-						sscanf(line, "%19s %f %f", tmp, &tek_sensor->offset, &tek_sensor->linearity);
+						sscanf(line, "%19s %f %f %hhx %hhu", tmp, &tek_sensor->offset, &tek_sensor->linearity, &tek_sensor->address, &tek_sensor->bus);
 						tek_sensor->offset*=16;
 					}
 

--- a/main.c
+++ b/main.c
@@ -522,6 +522,8 @@ int main (int argc, char **argv) {
 	static_sensor.comp2 = -0.0000004875;
 	static_sensor.comp1 = -0.2670286916;
 	static_sensor.comp0 = -18.7077108239;
+	static_sensor.address = 0x76;
+	static_sensor.bus = 1;
 
 	dynamic_sensor.offset = 0.0;
 	dynamic_sensor.linearity = 1.0;
@@ -534,6 +536,8 @@ int main (int argc, char **argv) {
 	tep_sensor.Pcomp2 = static_sensor.Pcomp2 = -0.0000004638;
 	tep_sensor.Pcomp1 = static_sensor.Pcomp1 =  0.9514328801;
 	tep_sensor.Pcomp0 = static_sensor.Pcomp0 =  0.1658634996;
+	tep_sensor.address = 0x77;
+	tep_sensor.bus = 1;
 
 	config.timing_log        = 0.066666666666666666666;
 	config.timing_mult       = 50;
@@ -642,8 +646,7 @@ int main (int argc, char **argv) {
 	{
 		// we need hardware sensors for running !!
 		// open sensor for static pressure
-		/// @todo remove hardcoded i2c address static pressure
-		if (ms5611_open(&static_sensor, 0x76) != 0)
+		if (ms5611_open(&static_sensor) != 0)
 		{
 			fprintf(stderr, "Open static sensor failed !!\n");
 			return 1;
@@ -657,8 +660,7 @@ int main (int argc, char **argv) {
 		static_sensor.valid = 1;
 
 		// open sensor for velocity pressure
-		/// @todo remove hardcoded i2c address for velocity pressure
-		if (ms5611_open(&tep_sensor, 0x77) != 0)
+		if (ms5611_open(&tep_sensor) != 0)
 		{
 			fprintf(stderr, "Open tep sensor failed !!\n");
 			return 1;
@@ -967,13 +969,13 @@ void print_runtime_config(void)
 	fprintf(stderr, "Sensor TEK:\n");
 	fprintf(stderr, "  Offset: \t%f\n",tep_sensor.offset);
 	fprintf(stderr, "  Linearity: \t%f\n", tep_sensor.linearity);
-	fprintf(stderr, "Sensor STATIC:\n");
-	fprintf(stderr, "  Offset: \t%f\n",static_sensor.offset);
+	fprintf(stderr, "  Address: \t0x%x\n", tep_sensor.address);
+	fprintf(stderr, "  Bus: \t\t%u\n", tep_sensor.bus);
 	fprintf(stderr, "  Linearity: \t%f\n", static_sensor.linearity);
 	fprintf(stderr, "Sensor TOTAL:\n");
 	fprintf(stderr, "  Offset: \t%f\n",dynamic_sensor.offset);
-	fprintf(stderr, "  Linearity: \t%f\n", dynamic_sensor.linearity);
-	fprintf(stderr, "=========================================================================\n");
+	fprintf(stderr, "  Address: \t0x%x\n", static_sensor.address);
+	fprintf(stderr, "  Bus: \t\t%u\n", static_sensor.bus);
 
 }
 

--- a/ms5611.c
+++ b/ms5611.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <linux/i2c-dev.h>
+#include <limits.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <string.h>
@@ -34,35 +35,35 @@
 /**
 * @brief Establish connection to MS5611 pressure sensor
 * @param sensor pointer to sensor instance
-* @param i2c_address
 * @return result
 *
 * @date 24.03.2016 revised
 *
 */
-int ms5611_open(t_ms5611 *sensor, unsigned char i2c_address)
+int ms5611_open(t_ms5611 *sensor)
 {
 	// local variables
 	int fd;
+	char i2c_dev[PATH_MAX] = {0};
+	sprintf(i2c_dev, "/dev/i2c-%hhu", sensor->bus);
 
 	// try to open I2C Bus
-	fd = open("/dev/i2c-1", O_RDWR);
+	fd = open(i2c_dev, O_RDWR);
 
 	if (fd < 0) {
-		fprintf(stderr, "Error opening file: %s\n", strerror(errno));
+		fprintf(stderr, "Error opening %s: %s\n", i2c_dev, strerror(errno));
 		return 1;
 	}
 
-	if (ioctl(fd, I2C_SLAVE, i2c_address) < 0) {
+	if (ioctl(fd, I2C_SLAVE, sensor->address) < 0) {
 		fprintf(stderr, "ioctl error: %s\n", strerror(errno));
 		return 1;
 	}
 
-	if (g_debug > 0) fprintf(stderr, "Opened MS5611 on 0x%x\n", i2c_address);
+	if (g_debug > 0) fprintf(stderr, "Opened MS5611 on bus %s with address 0x%x\n", i2c_dev, sensor->address);
 
 	// assign file handle to sensor object
 	sensor->fd = fd;
-	sensor->address = i2c_address;
 	return (0);
 }
 

--- a/ms5611.h
+++ b/ms5611.h
@@ -27,6 +27,7 @@
 typedef struct {
 	int fd;
 	unsigned char address;
+	uint8_t bus;
 	uint32_t C1s;
 	uint32_t C2s;
 	uint16_t C3;
@@ -62,7 +63,7 @@ int ms5611_init(t_ms5611 *);
 int ms5611_reset(t_ms5611 *);
 int ms5611_measure(t_ms5611 *);
 int ms5611_calculate(t_ms5611 *);
-int ms5611_open(t_ms5611 *, unsigned char);
+int ms5611_open(t_ms5611 *);
 
 int ms5611_calculate_pressure(t_ms5611 *);
 int ms5611_read_pressure(t_ms5611 *);

--- a/sensord.conf
+++ b/sensord.conf
@@ -1,14 +1,14 @@
 #Section for static pressure sensor
 # Unit: Pa
-#format: static_sensor [offset] [linearity]
-#Example: static_sensor 1.5 1.3
-static_sensor 0.0 1.0
+#format: static_sensor [offset] [linearity] [i2c address] [i2c bus]
+#Example: static_sensor 1.5 1.3 0x76 1
+static_sensor 0.0 1.0 0x76 1
 
 #Section for tek pressure sensor
 # Unit: Pa
 #format: tek_sensor [offset] [linearity]
 #Example: tek_sensor 1.5 1.3
-tek_sensor 0.0 1.0
+tek_sensor 0.0 1.0 0x77 1
 
 #Section for dynamic pressure sensor
 # Unit: Pa


### PR DESCRIPTION
Hi all,
this is a RFC to make the i2c address and bus used for the ms5611 sensors configurable with sensord.conf.

It alters the sonsord.conf  static_sensor and tek_sensor entries with address and bus fields. It keeps the current values as defaults. I'm not sure if it is a good idea to mix the pressure settings with the device settings. I can change that on demand.

There was already a address field in the sensor struct so I extended it with a bus filed.

This allows me to use two sensors, for which the pull ups for the addresses are hard wired, on two different i2c buses.